### PR TITLE
setup.py: declare encoding as utf-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import io
 import os
 import sys


### PR DESCRIPTION
the ellipsis (…) causes troubles otherwise on "old" python versions as 3.6