### PR TITLE
Fix: Import error sre_parse

### DIFF
--- a/exrex.py
+++ b/exrex.py
@@ -22,7 +22,11 @@ try:
     from future_builtins import map, range
 except:
     pass
-from re import match, sre_parse, U
+from re import match, U
+try:
+    import re._parser as sre_parse
+except ImportError: # Python < 3.11
+    from re import sre_parse
 from itertools import tee
 from random import choice, randint
 from types import GeneratorType

--- a/tests.py
+++ b/tests.py
@@ -20,8 +20,12 @@
 
 from exrex import generate, count, getone, CATEGORIES, simplify
 import re
-import sre_parse
+try: 
+    import re._parser as sre_parse
+except ImportError: # Python < 3.11
+    from re import sre_parse
 from sys import exit, version_info
+
 IS_PY3 = version_info[0] == 3
 
 RS = {


### PR DESCRIPTION
sre_parse module was moved in py3.11.

See: python/cpython#91308

Fixes #63 