### PR TITLE
fix invalid escape sequence in regex

### DIFF
--- a/exrex.py
+++ b/exrex.py
@@ -52,9 +52,9 @@ CATEGORIES = {
     sre_parse.CATEGORY_SPACE: sorted(sre_parse.WHITESPACE),
     sre_parse.CATEGORY_DIGIT: sorted(sre_parse.DIGITS),
     sre_parse.CATEGORY_WORD: [unichr(x) for x in range(256) if
-                              match('\w', unichr(x), U)],
+                              match(r'\w', unichr(x), U)],
     sre_parse.CATEGORY_NOT_WORD: [unichr(x) for x in range(256) if
-                                  match('\W', unichr(x), U)],
+                                  match(r'\W', unichr(x), U)],
     'category_any': [unichr(x) for x in range(32, 123)]
 }
 


### PR DESCRIPTION
`\w` without the `r` prefix is considered an escape sequence, and an invalid one. Invalid escape sequences are a syntax warning and will become syntax errors very soon. It's pretty annoying and is even more since exrex is a dependencies of the popular `pydantic_factories` python package. It is currently breaking our test suite since we updated to a more up to date environment, with this kind of error:

```
  File "/Users/mathieu/dev/our-package/.tox/py311/lib/python3.11/site-packages/pydantic_factories/__init__.py", line 3, in <module>
    from .extensions import (
  File "/Users/mathieu/dev/our-package/.tox/py311/lib/python3.11/site-packages/pydantic_factories/extensions/__init__.py", line 2, in <module>
    from .beanie_odm import BeanieDocumentFactory, BeaniePersistenceHandler
  File "/Users/mathieu/dev/our-package/.tox/py311/lib/python3.11/site-packages/pydantic_factories/extensions/beanie_odm.py", line 6, in <module>
    from pydantic_factories.factory import ModelFactory
  File "/Users/mathieu/dev/our-package/.tox/py311/lib/python3.11/site-packages/pydantic_factories/factory.py", line 94, in <module>
    from pydantic_factories.constraints.strings import (
  File "/Users/mathieu/dev/our-package/.tox/py311/lib/python3.11/site-packages/pydantic_factories/constraints/strings.py", line 3, in <module>
    from exrex import getone  # pylint: disable=import-error
    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/mathieu/dev/gg-django/.tox/py311/bin/exrex.py", line 55
    match('\w', unichr(x), U)],
          ^^^^
SyntaxError: invalid escape sequence '\w'
```

This change is totally safe to merge.