### PR TITLE
Bugfix: correct processing of empty patterns like '()'

### DIFF
--- a/exrex.py
+++ b/exrex.py
@@ -217,10 +217,17 @@ def _gen(d, limit=20, count=False, grouprefs=None):
             subexpr = i[1][1]
             if IS_PY36_OR_GREATER and i[0] == sre_parse.SUBPATTERN:
                 subexpr = i[1][3]
-            if count:
-                strings = (
-                    strings or 1) * (sum(ggen([0], _gen, subexpr, limit=limit, count=True, grouprefs=grouprefs)) or 1)
-            ret = ggen(ret, _gen, subexpr, limit=limit, count=False, grouprefs=grouprefs, groupref=i[1][0])
+
+            if len(subexpr) == 0:
+                # for subpattern like ()
+                ret = mappend(ret, '')
+                if count:
+                    strings = strings or 1
+            else:
+                if count:
+                    strings = (
+                        strings or 1) * (sum(ggen([0], _gen, subexpr, limit=limit, count=True, grouprefs=grouprefs)) or 1)
+                ret = ggen(ret, _gen, subexpr, limit=limit, count=False, grouprefs=grouprefs, groupref=i[1][0])
         # ignore ^ and $
         elif i[0] == sre_parse.AT:
             continue

--- a/tests.py
+++ b/tests.py
@@ -51,7 +51,9 @@ RS = {
     '(?=x)': ['x'],
     '\\da{2}': ['0aa', '1aa', '2aa', '3aa', '4aa', '5aa', '6aa', '7aa', '8aa', '9aa'],
     '\\w': CATEGORIES[sre_parse.CATEGORY_WORD],
-    '\\W': CATEGORIES[sre_parse.CATEGORY_NOT_WORD]
+    '\\W': CATEGORIES[sre_parse.CATEGORY_NOT_WORD],
+    '()': [''],
+    '((\'s)|( is)|())': ['\'s', ' is', '']
 }
 
 BIGS = [


### PR DESCRIPTION
exrex was throwing exceptions on the regexps with an empty sub-pattern, like these: 
- ()
- ((\'s)|( is)|())